### PR TITLE
Animate once by default

### DIFF
--- a/animate-in-view.php
+++ b/animate-in-view.php
@@ -4,7 +4,7 @@
  * Description:       This block will animate in as soon as it enters the viewport of the browser window. That's it.
  * Requires at least: 5.9
  * Requires PHP:      7.0
- * Version:           1.0.4
+ * Version:           1.1.0
  * Author:            Kevin Batdorf
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      kbat82
 Tags:              animate, block, fade, screen, slide-in, viewport, intersection
 Tested up to:      5.9
-Stable tag:        1.0.4
+Stable tag:        1.1.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -54,6 +54,9 @@ This keeps block functionality composable. This block is very lightweight and do
 2. Minimum controls to get the best results
 
 == Changelog ==
+
+= 1.1.0 =
+* Switch to only showing once by default
 
 = 1.0.4 =
 * Adds content overflow strategy

--- a/src/block.json
+++ b/src/block.json
@@ -17,7 +17,7 @@
         },
         "once": {
             "type": "number",
-            "default": 0
+            "default": 1
         },
         "direction": {
             "type": "number",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,7 @@ registerBlockType<Attributes>(blockConfig.name, {
         },
         once: {
             type: 'number',
-            default: 0,
+            default: 1,
         },
         direction: {
             type: 'number',


### PR DESCRIPTION
This just changes the default for the Once vs Infinite option to default to once. I feel like that's a better default behavior. 