### PR TITLE
Add enable/disable toggle

### DIFF
--- a/animate-in-view.php
+++ b/animate-in-view.php
@@ -4,7 +4,7 @@
  * Description:       This block will animate in as soon as it enters the viewport of the browser window. That's it.
  * Requires at least: 5.9
  * Requires PHP:      7.0
- * Version:           1.1.0
+ * Version:           1.2.0
  * Author:            Kevin Batdorf
  * License:           GPL-2.0-or-later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Animate In View ===
 Contributors:      kbat82
 Tags:              animate, block, fade, screen, slide-in, viewport, intersection
-Tested up to:      5.9
-Stable tag:        1.1.0
+Tested up to:      6.0
+Stable tag:        1.2.0
 License:           GPL-2.0-or-later
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -54,6 +54,10 @@ This keeps block functionality composable. This block is very lightweight and do
 2. Minimum controls to get the best results
 
 == Changelog ==
+
+= 1.2.0 =
+* Add enable/disable button
+* Return function instead of component from filter
 
 = 1.1.0 =
 * Switch to only showing once by default

--- a/src/editor/Controls.tsx
+++ b/src/editor/Controls.tsx
@@ -33,6 +33,22 @@ export const Controls = ({ attributes, setAttributes }: ControlProps) => {
                 <PanelBody title={__('Settings', 'animate-in-view')}>
                     <BaseControl id="main-settings">
                         <div className="animate-in-view-editor">
+                            <ToggleGroupControl
+                                onChange={(value: number) =>
+                                    update('enabled', value)
+                                }
+                                label={__('Enabled', 'animate-in-view')}
+                                value={attributes.enabled}
+                                isBlock>
+                                <ToggleGroupControlOption
+                                    value={1}
+                                    label={__('Enabled', 'animate-in-view')}
+                                />
+                                <ToggleGroupControlOption
+                                    value={0}
+                                    label={__('Disabled', 'animate-in-view')}
+                                />
+                            </ToggleGroupControl>
                             <RangeControl
                                 label={__(
                                     'Visibility threshold',

--- a/src/editor/ToolbarMenu.tsx
+++ b/src/editor/ToolbarMenu.tsx
@@ -9,10 +9,16 @@ import { __ } from '@wordpress/i18n'
 import blockConfig from '../block.json'
 import { blockIcon } from '../icons'
 
-export const ToolbarMenu = (props: any) => {
-    const { clientId, CurrentMenuItems } = props
-    const { getBlock, getBlockParents, getBlockName } =
-        useSelect(blockEditorStore)
+export const ToolbarMenu = (
+    CurrentMenuItems: React.ComponentType,
+    props: any,
+) => {
+    const { clientId } = props
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore-next-line - getBlock not added as a type?
+    const { getBlock, getBlockParents, getBlockName } = useSelect((select) =>
+        select(blockEditorStore),
+    )
     // @ts-ignore-next-line - replaceBlock not added as a type?
     const { replaceBlock } = useDispatch(blockEditorStore)
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -79,6 +79,6 @@ registerBlockType<Attributes>(blockConfig.name, {
 addFilter(
     'editor.BlockEdit',
     blockConfig.name,
-    (CurrentMenuItems) => (props: any) =>
-        <ToolbarMenu CurrentMenuItems={CurrentMenuItems} {...props} />,
+    // Gutenberg seems to require this to be a function.
+    (CurrentMenuItems) => (props: any) => ToolbarMenu(CurrentMenuItems, props),
 )


### PR DESCRIPTION
This adds an enable/disable toggle.

It also seems WP is requiring the BlockEdit component be returned at the top level, so this does that too. Hopefully fixing some compatibility issues.